### PR TITLE
include string header for compilation error

### DIFF
--- a/include/Clipboard_Lite.h
+++ b/include/Clipboard_Lite.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <functional>
 #include <memory>
+#include <string>
 
 #if defined(WINDOWS) || defined(WIN32)
 #if defined(CLIPBOARD_LITE_DLL)


### PR DESCRIPTION
I met compilation error on MSVC 16:

```
include\Clipboard_Lite.h(31,38): error C2039: 'string': is not a member of 'std' 
```

It seems to be caused by lack of string header in Clipbode_Lite.h.
Please apply this patch if possible.
